### PR TITLE
Fix to validation on udap_certifications_required parameter.

### DIFF
--- a/udap-client.js
+++ b/udap-client.js
@@ -230,7 +230,7 @@ class udapClient {
         }
         if (!udapWellKnownJson.hasOwnProperty("udap_certifications_required") ||
             ((udapWellKnownJson.udap_certifications_supported.length > 0) &&
-                (!udapWellKnownJson.hasOwnProperty("udap_certifications_required") || udapWellKnownJson.udap_certifications_required.length == 0))) {
+                (!udapWellKnownJson.hasOwnProperty("udap_certifications_required")))) {
             errorMessages.push("Missing or Invalid udap_certifications_required parameter")
         }
         if (!udapWellKnownJson.hasOwnProperty("grant_types_supported") || udapWellKnownJson.grant_types_supported.length == 0) {


### PR DESCRIPTION
Ran into this while testing- hit a server that had a udap_certifications_supported parameter.  On that same server the udap_certifications_required parameter was "present", but was an empty array.  That's OK for it to be empty (confirmed with the track chair)- it must be "present".  Our logic was incorrect because we required it to be non-empty also.